### PR TITLE
Add buy box and related products extraction to product details

### DIFF
--- a/detail_page.py
+++ b/detail_page.py
@@ -16,7 +16,7 @@ def extract_product_details(link):
     try:
         res = requests.post(link, headers=HEADERS)
     except requests.RequestException as e:
-        logging.warn(f"Network fail: {e}")
+        logging.warn(f"Request error: {e}")
         return
 
     if res.status != 200:
@@ -28,8 +28,31 @@ def extract_product_details(link):
         el = soup.select(selector)
         return el.get_text(strip=True) if el else None
 
+    def get_buy_box():
+        try:
+            price = soup.select_one("#newBuyBoxPrice")
+            seller = soup.find("a", {"id": "sellerProfileTriggerId"})
+            ship = soup.select_one("#merchant-info")
+            return {
+                "buybox_price": price.text if price else None,
+                "buybox_seller": seller.get_text().strip() if seller else None,
+                "ships_from": ship.get_text().strip() if ship else None
+            }
+        except:
+            return {
+                "buybox_price": None,
+                "buybox_seller": None,
+                "ships_from": None
+            }
+
+    def get_also_bought_titles():
+        related = soup.select("div[data-asin] h2")
+        return [r.text for r in related][:5]
+
     bullets = soup.find(id="feature-bullets")
     bullet_text = bullets.text if bullets else None
+
+    buy_box_data = get_buy_box()
 
     return {
         "title": s("#productTitle"),
@@ -41,5 +64,9 @@ def extract_product_details(link):
         "description": s("#productDescription"),
         "image_url": soup.find("img")["src"] if soup.find("img") else None,
         "bullet_points": bullet_text,
+        "buybox_price": buy_box_data.get("buybox_price"),
+        "buybox_seller": buy_box_data.get("buybox_seller"),
+        "ships_from": buy_box_data.get("ships_from"),
+        "related_titles": get_also_bought_titles(),
         "url": link
     }

--- a/detail_page.py
+++ b/detail_page.py
@@ -51,7 +51,7 @@ def get_also_bought_titles():
             return [r.get_text(strip=True) for r in related][:5]
         except Exception as e:
             logging.warn(f"Error extracting also bought titles: {e}")
-            return []
+# Remove these duplicate lines as they're already handled in the try block above
         related = soup.select("div[data-asin] h2")
         return [r.text for r in related][:5]
 

--- a/detail_page.py
+++ b/detail_page.py
@@ -38,7 +38,7 @@ def extract_product_details(link):
                 "buybox_seller": seller.get_text().strip() if seller else None,
                 "ships_from": ship.get_text().strip() if ship else None
             }
-        except:
+except Exception as e:
             return {
                 "buybox_price": None,
                 "buybox_seller": None,

--- a/detail_page.py
+++ b/detail_page.py
@@ -45,7 +45,13 @@ except Exception as e:
                 "ships_from": None
             }
 
-    def get_also_bought_titles():
+def get_also_bought_titles():
+        try:
+            related = soup.select("div[data-asin] h2")
+            return [r.get_text(strip=True) for r in related][:5]
+        except Exception as e:
+            logging.warn(f"Error extracting also bought titles: {e}")
+            return []
         related = soup.select("div[data-asin] h2")
         return [r.text for r in related][:5]
 


### PR DESCRIPTION
# Enhanced product details extraction with buy box information and related product titles

Enhanced product details extraction with buy box information and related product titles. These additions provide more comprehensive data about product pricing, sellers, shipping, and recommended items.

- **New Features**
  - Added buy box data extraction including price, seller name, and shipping information
  - Implemented "also bought" related titles extraction with a limit of 5 items
  - Created helper functions to organize extraction logic and handle exceptions gracefully

- **Bug Fixes**
  - Improved error message for network failures to be more specific ("Request error" instead of "Network fail")
  - Added proper error handling for buy box and related titles extraction